### PR TITLE
Fix invalid uploadDirectory paths containing . and ..

### DIFF
--- a/scripts/upload.js
+++ b/scripts/upload.js
@@ -4,13 +4,24 @@
  * Example usage: node scripts/upload.js <file-to-upload>
  */
 
+const fs = require("fs");
 const process = require("process");
 
 const { SkynetClient } = require("..");
 
 const client = new SkynetClient();
 
-const promises = process.argv.slice(2).map((path) => client.uploadFile(path));
+const promises = process.argv
+  // Ignore the first two arguments.
+  .slice(2)
+  // Use appropriate function for dir or for file. Note that this throws if the
+  // path doesn't exist; we print an error later.
+  .map((path) =>
+    fs.promises
+      .lstat(path)
+      .then((stat) => (stat.isDirectory() ? client.uploadDirectory(path) : client.uploadFile(path)))
+  );
+
 (async () => {
   const results = await Promise.allSettled(promises);
   results.forEach((result) => {

--- a/src/upload.js
+++ b/src/upload.js
@@ -124,7 +124,7 @@ SkynetClient.prototype.uploadDirectory = async function (path, customOptions = {
   }
 
   const formData = new FormData();
-  path = p.normalize(path);
+  path = p.resolve(path);
   let basepath = path;
   // Ensure the basepath ends in a slash.
   if (!basepath.endsWith("/")) {
@@ -142,7 +142,8 @@ SkynetClient.prototype.uploadDirectory = async function (path, customOptions = {
     formData.append(opts.portalDirectoryFileFieldname, fs.createReadStream(file), { filepath: filename });
   }
 
-  let filename = opts.customDirname || path;
+  // Use either the custom dirname, or the last portion of the path.
+  let filename = opts.customDirname || p.basename(path);
   if (filename.startsWith("/")) {
     filename = filename.slice(1);
   }

--- a/src/upload.test.js
+++ b/src/upload.test.js
@@ -171,6 +171,17 @@ describe("uploadDirectory", () => {
     }
   });
 
+  // Test that . and .. get resolved as these are not allowed in Sia paths.
+  it("should resolve paths containing . and ..", async () => {
+    await client.uploadDirectory(`${dirname}/./../${dirname}/.`);
+
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { filename: dirname },
+      })
+    );
+  });
+
   it("should send post request to client portal", async () => {
     const newPortalUrl = "https://siasky.xyz";
     const client = new SkynetClient(newPortalUrl);


### PR DESCRIPTION
# PULL REQUEST

## Overview

Trying to call `uploadDirectory(".")` was failing because Sia does not allow `.` in Sia paths:

```
"failed to upload file to skynet: [unable to upload skyfile; unable to create skylink from filenode; metadata is invalid; [invalid filename provided '.'; invalid path string; path cannot be '.']]"
```

This PR fixes that by resolving any instances of `.` and `..`.