### PR TITLE
Fix `getMetadata`

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -44,6 +44,7 @@ class SkynetClient {
 
     // Download
     this.getSkylinkUrl = browserClient.getSkylinkUrl.bind(browserClient);
+    this.getMetadata = browserClient.getMetadata.bind(browserClient);
 
     // File API
     this.file = {

--- a/src/download.js
+++ b/src/download.js
@@ -39,9 +39,3 @@ SkynetClient.prototype.downloadFile = function (path, skylink, customOptions = {
       });
   });
 };
-
-SkynetClient.prototype.getMetadata = function (skylink, customOptions = {}) {
-  const opts = { ...defaultGetMetadataOptions, ...this.customOptions, ...customOptions };
-
-  throw new Error("Unimplemented");
-};


### PR DESCRIPTION
# PULL REQUEST

## Overview

Fixes `getMetadata` so that it uses `skynet-js` internally instead of erroring.