### PR TITLE
Pass options to skynet-js

### DIFF
--- a/scripts/get-metadata.js
+++ b/scripts/get-metadata.js
@@ -1,0 +1,27 @@
+/**
+ * Demo script that gets metadata for all skylinks passed in as CLI arguments.
+ *
+ * Example usage: node scripts/get-metadata.js <skylink>
+ */
+
+const process = require("process");
+
+const { SkynetClient } = require("..");
+
+const client = new SkynetClient();
+
+const promises = process.argv
+  // Ignore the first two arguments.
+  .slice(2)
+  .map(async (skylink) => await client.getMetadata(skylink));
+
+(async () => {
+  const results = await Promise.allSettled(promises);
+  results.forEach((result) => {
+    if (result.status === "fulfilled") {
+      console.log(result.value);
+    } else {
+      console.log(result.reason);
+    }
+  });
+})();

--- a/src/client.js
+++ b/src/client.js
@@ -35,7 +35,7 @@ class SkynetClient {
     // Re-export selected client methods from skynet-js.
 
     // Create the browser client. It requires an explicit portal URL to be passed in Node contexts. We also have to pass valid custom options, so we remove any unexpected ones.
-    const browserClientOptions = this.customOptions;
+    const browserClientOptions = { ...this.customOptions };
     delete browserClientOptions.portalUrl;
     const browserClient = new BrowserSkynetClient(portalUrl || defaultPortalUrl(), browserClientOptions);
     this.browserClient = browserClient;

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,7 @@
 const axios = require("axios");
 const { SkynetClient: BrowserSkynetClient } = require("skynet-js");
 
-const { makeUrl } = require("./utils.js");
+const { defaultPortalUrl, makeUrl } = require("./utils.js");
 
 class SkynetClient {
   /**
@@ -9,15 +9,10 @@ class SkynetClient {
    * @constructor
    * @param {string} [portalUrl="https://siasky.net"] - The portal URL to use to access Skynet, if specified. To use the default portal while passing custom options, use "".
    * @param {Object} [customOptions={}] - Configuration for the client.
-   * @param {string} [customOptions.method] - HTTP method to use.
    * @param {string} [customOptions.APIKey] - Authentication password to use.
    * @param {string} [customCookie=""] - Custom cookie header to set.
    * @param {string} [customOptions.customUserAgent=""] - Custom user agent header to set.
-   * @param {Object} [customOptions.data=null] - Data to send in a POST.
-   * @param {string} [customOptions.endpointPath=""] - The relative URL path of the portal endpoint to contact.
-   * @param {string} [customOptions.extraPath=""] - Extra path element to append to the URL.
    * @param {Function} [customOptions.onUploadProgress] - Optional callback to track progress.
-   * @param {Object} [customOptions.params={}] - Query parameters to include in the URl.
    */
   constructor(portalUrl, customOptions = {}) {
     // Check if portal URL provided twice.
@@ -39,7 +34,10 @@ class SkynetClient {
 
     // Re-export selected client methods from skynet-js.
 
-    let browserClient = new BrowserSkynetClient(portalUrl);
+    // Create the browser client. It requires an explicit portal URL to be passed in Node contexts. We also have to pass valid custom options, so we remove any unexpected ones.
+    const browserClientOptions = this.customOptions;
+    delete browserClientOptions.portalUrl;
+    const browserClient = new BrowserSkynetClient(portalUrl || defaultPortalUrl(), browserClientOptions);
     this.browserClient = browserClient;
 
     // Download
@@ -61,7 +59,8 @@ class SkynetClient {
     this.registry = {
       getEntry: browserClient.registry.getEntry.bind(browserClient),
       getEntryUrl: browserClient.registry.getEntryUrl.bind(browserClient),
-      getEntryLink: browserClient.registry.getEntryLink.bind(browserClient),
+      // Don't bind the client since this method doesn't take the client.
+      getEntryLink: browserClient.registry.getEntryLink,
       setEntry: browserClient.registry.setEntry.bind(browserClient),
       postSignedEntry: browserClient.registry.postSignedEntry.bind(browserClient),
     };

--- a/src/download.test.js
+++ b/src/download.test.js
@@ -32,11 +32,12 @@ describe("download", () => {
     tmpFile.removeCallback();
   });
 
-  it("should use custom options if defined", () => {
+  it("should use custom options if defined on the API call", () => {
     const tmpFile = tmp.fileSync();
 
     client.downloadFile(tmpFile.name, skylink, {
       portalUrl: "http://localhost",
+      customCookie: "skynet-jwt=foo",
     });
 
     expect(axios).toHaveBeenCalledWith(
@@ -44,6 +45,7 @@ describe("download", () => {
         url: `http://localhost/${skylink}`,
         method: "get",
         responseType: "stream",
+        headers: expect.objectContaining({ Cookie: "skynet-jwt=foo" }),
       })
     );
 
@@ -52,15 +54,23 @@ describe("download", () => {
 
   it("should use custom connection options if defined on the client", () => {
     const tmpFile = tmp.fileSync();
-    const client = new SkynetClient("", { APIKey: "foobar", customUserAgent: "Sia-Agent" });
+    const client = new SkynetClient("", {
+      APIKey: "foobar",
+      customUserAgent: "Sia-Agent",
+      customCookie: "skynet-jwt=foo",
+    });
 
-    client.downloadFile(tmpFile.name, skylink, { APIKey: "barfoo", customUserAgent: "Sia-Agent-2" });
+    client.downloadFile(tmpFile.name, skylink, {
+      APIKey: "barfoo",
+      customUserAgent: "Sia-Agent-2",
+      customCookie: "skynet-jwt=bar",
+    });
 
     expect(axios).toHaveBeenCalledWith(
       expect.objectContaining({
         url: `${portalUrl}/${skylink}`,
         auth: { username: "", password: "barfoo" },
-        headers: expect.objectContaining({ "User-Agent": "Sia-Agent-2" }),
+        headers: expect.objectContaining({ "User-Agent": "Sia-Agent-2", Cookie: "skynet-jwt=bar" }),
       })
     );
 

--- a/src/upload.test.js
+++ b/src/upload.test.js
@@ -83,7 +83,11 @@ describe("uploadFile", () => {
   });
 
   it("should use custom connection options if defined on the client", async () => {
-    const client = new SkynetClient("", { APIKey: "foobar", customUserAgent: "Sia-Agent" });
+    const client = new SkynetClient("", {
+      APIKey: "foobar",
+      customUserAgent: "Sia-Agent",
+      customCookie: "skynet-jwt=foo",
+    });
 
     await client.uploadFile(filename);
 
@@ -96,16 +100,24 @@ describe("uploadFile", () => {
           ]),
         }),
         auth: { username: "", password: "foobar" },
-        headers: expect.objectContaining({ "User-Agent": "Sia-Agent" }),
+        headers: expect.objectContaining({ "User-Agent": "Sia-Agent", Cookie: "skynet-jwt=foo" }),
         params: expect.anything(),
       })
     );
   });
 
   it("should use custom connection options if defined on the API call", async () => {
-    const client = new SkynetClient("", { APIKey: "foobar", customUserAgent: "Sia-Agent" });
+    const client = new SkynetClient("", {
+      APIKey: "foobar",
+      customUserAgent: "Sia-Agent",
+      customCookie: "skynet-jwt=foo",
+    });
 
-    await client.uploadFile(filename, { APIKey: "barfoo", customUserAgent: "Sia-Agent-2" });
+    await client.uploadFile(filename, {
+      APIKey: "barfoo",
+      customUserAgent: "Sia-Agent-2",
+      customCookie: "skynet-jwt=bar",
+    });
 
     expect(axios).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -116,7 +128,7 @@ describe("uploadFile", () => {
           ]),
         }),
         auth: { username: "", password: "barfoo" },
-        headers: expect.objectContaining({ "User-Agent": "Sia-Agent-2" }),
+        headers: expect.objectContaining({ "User-Agent": "Sia-Agent-2", Cookie: "skynet-jwt=bar" }),
         params: expect.anything(),
       })
     );


### PR DESCRIPTION
# PULL REQUEST

## Overview

- Options were not being marshaled from the `nodejs` client to the `skynet-js` client.
- Fix an issue with `getEntryLink`
- Fix `skynet-js` client initialization in Node context (portal URL undefined).

## Testing

### get-metadata.js script

I tested this manually, by inserting a `console.log` in `skynet-js` to make sure the options were being marshaled and then calling the new `get-metadata.js` script included.

```
$ node scripts/get-metadata.js AABPMue-1MjiRQR2L7CcHBpugqk1ItkVptD2UhmfQ5HkZQ

{
  APIKey: '',
  customUserAgent: '',
  customCookie: 'skynet-jst=foo',
  onDownloadProgress: undefined,
  onUploadProgress: undefined,
  endpointGetMetadata: '/skynet/metadata',
  method: 'GET',
  url: 'https://siasky.net/skynet/metadata/AABPMue-1MjiRQR2L7CcHBpugqk1ItkVptD2UhmfQ5HkZQ'
}
```

### Deploy Script

I also tested that the deploy script in `skynet-mysky` still works by `npm link`ing to these changes:

```
$ node utilities/deploy.js 
Sending to Skynet...
📡 App deployed to Skynet with skylink: sia://AAAkXR-L-T-2k5dkhgaO_2e6dmqBLc-hZbtHEDlUozy1_g
📡 Resolver skylink updated: sia://AQAZOrwWJb5gYQ-WHirJI0S_bIFtEcGIxBGMrKBBaf1m9g
🚀 Deployment to Skynet complete!

Use the links below to access your app:
   Immutable Skylink Url: https://00028n8vhfsjvdkjiti8c1kevtjrktjag4msv8b5nd3h0eakkcubbvg.siasky.net/
   Resolver Skylink Url: https://0401iels2oirso311ub1sam94d2bur41dk8s3264266ap821d7umdtg.siasky.net/

Each new deployment will have a unique skylink while the "resolver skylink" will always point at the most recent deployment.
It is recommended that you share the resolver skylink url so that people always see the newest version of your app.
You can use the resolver skylink (starting with `sia://`) for setting ENS content hashes for a decentralized domain.
```