### PR TITLE
Add support for in-memory uploads/downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Types of changes:
+
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Removed` for now removed features.
+- `Deprecated` for soon-to-be removed features.
+- `Fixed` for any bug fixes.
+- `Security` in case of vulnerabilities.
+
+## Unreleased
+
+### Added
+
+- Add `uploadData` and `downloadData`
+
 ## [2.5.1]
 
-### Changed
+### Fixed
 
 - Fix `skynetApiKey` not being passed for certain methods.
 
@@ -14,7 +34,7 @@
 
 ## [2.4.1]
 
-### Changed
+### Fixed
 
 - Fix Options not being marshaled from the `nodejs` client to the `skynet-js` client.
 - Fix an issue with `client.getEntryLink`.
@@ -28,7 +48,7 @@
 
 ## [2.3.1]
 
-### Changed
+### Fixed
 
 - Fixed bug with paths containing `.` and `..` as inputs to `uploadDirectory`.
 
@@ -48,7 +68,7 @@
 
 - Added `errorPages` and `tryFiles` options when uploading directories
 
-### Changed
+### Fixed
 
 - Fixed custom client portal URL being ignored
 
@@ -61,11 +81,14 @@
 
 ## [2.0.1]
 
+## Fixed
+
+- Fixed length limits for request bodies.
+- Fixed upload errors due to missing headers.
+
 ### Changed
 
 - Remove leading slash in directory path before uploading an absolute path.
-- Fixed length limits for request bodies.
-- Fixed upload errors due to missing headers.
 
 ## [2.0.0]
 
@@ -90,7 +113,7 @@
 - API authentication
 - `dryRun` option
 
-### Changed
+### Fixed
 
 - Some upload bugs were fixed.
 

--- a/scripts/download-data.js
+++ b/scripts/download-data.js
@@ -1,10 +1,9 @@
 /**
- * Demo script that uploads all paths passed in as CLI arguments.
+ * Demo script that downloads data for all skylinks passed in as CLI arguments.
  *
- * Example usage: node scripts/upload.js <path-to-file-to-upload>
+ * Example usage: node scripts/download-data.js <skylink>
  */
 
-const fs = require("fs");
 const process = require("process");
 
 const { SkynetClient } = require("..");
@@ -14,13 +13,7 @@ const client = new SkynetClient();
 const promises = process.argv
   // Ignore the first two arguments.
   .slice(2)
-  // Use appropriate function for dir or for file. Note that this throws if the
-  // path doesn't exist; we print an error later.
-  .map((path) =>
-    fs.promises
-      .lstat(path)
-      .then((stat) => (stat.isDirectory() ? client.uploadDirectory(path) : client.uploadFile(path)))
-  );
+  .map(async (skylink) => await client.downloadData(skylink));
 
 (async () => {
   const results = await Promise.allSettled(promises);

--- a/scripts/upload-data.js
+++ b/scripts/upload-data.js
@@ -1,0 +1,20 @@
+/**
+ * Demo script that uploads data passed in as CLI arguments.
+ *
+ * Example usage: node scripts/upload-data.js <filename> <data-string>
+ */
+
+const process = require("process");
+
+const { SkynetClient } = require("..");
+
+const client = new SkynetClient();
+
+(async () => {
+  const filename = process.argv[2];
+  const data = process.argv[3];
+
+  const skylink = await client.uploadData(data, filename);
+
+  console.log(skylink);
+})();

--- a/src/download.js
+++ b/src/download.js
@@ -15,6 +15,20 @@ const defaultGetMetadataOptions = {
   ...defaultOptions("/"),
 };
 
+SkynetClient.prototype.downloadData = async function (skylink, customOptions = {}) {
+  const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
+
+  skylink = trimSiaPrefix(skylink);
+
+  const response = await this.executeRequest({
+    ...opts,
+    method: "get",
+    extraPath: skylink,
+    responseType: "arraybuffer",
+  });
+  return response.data;
+};
+
 SkynetClient.prototype.downloadFile = function (path, skylink, customOptions = {}) {
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
 

--- a/src/download.js
+++ b/src/download.js
@@ -15,6 +15,13 @@ const defaultGetMetadataOptions = {
   ...defaultOptions("/"),
 };
 
+/**
+ * Downloads in-memory data from a skylink.
+ *
+ * @param {string} skylink - The skylink.
+ * @param {Object} [customOptions={}] - Configuration options.
+ * @returns - The data.
+ */
 SkynetClient.prototype.downloadData = async function (skylink, customOptions = {}) {
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
 

--- a/src/download.test.js
+++ b/src/download.test.js
@@ -9,7 +9,7 @@ const portalUrl = defaultPortalUrl();
 const skylink = "XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg";
 const client = new SkynetClient();
 
-describe("download", () => {
+describe("downloadFile", () => {
   const body = "asdf";
 
   beforeEach(() => {
@@ -81,5 +81,27 @@ describe("download", () => {
     );
 
     tmpFile.removeCallback();
+  });
+});
+
+describe("downloadData", () => {
+  const body = "asdf";
+
+  beforeEach(() => {
+    axios.mockResolvedValue({ data: body });
+  });
+
+  it("should send get request to default portal", async () => {
+    const data = await client.downloadData(skylink);
+
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: `${portalUrl}/${skylink}`,
+        method: "get",
+        responseType: "arraybuffer",
+      })
+    );
+
+    expect(data).toEqual(body);
   });
 });

--- a/src/upload.js
+++ b/src/upload.js
@@ -35,6 +35,14 @@ const defaultUploadOptions = {
   tryFiles: undefined,
 };
 
+/**
+ * Uploads in-memory data to Skynet.
+ *
+ * @param {string|Buffer} data - The data to upload, either a string or raw bytes.
+ * @param {string} filename - The filename to use on Skynet.
+ * @param {Object} [customOptions={}] - Configuration options.
+ * @returns - The skylink.
+ */
 SkynetClient.prototype.uploadData = async function (data, filename, customOptions = {}) {
   const opts = { ...defaultUploadOptions, ...this.customOptions, ...customOptions };
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -35,6 +35,27 @@ const defaultUploadOptions = {
   tryFiles: undefined,
 };
 
+SkynetClient.prototype.uploadData = async function (data, filename, customOptions = {}) {
+  const opts = { ...defaultUploadOptions, ...this.customOptions, ...customOptions };
+
+  const params = {};
+  if (opts.dryRun) params.dryrun = true;
+
+  const formData = new FormData();
+  formData.append(opts.portalFileFieldname, data, filename);
+
+  const response = await this.executeRequest({
+    ...opts,
+    method: "post",
+    data: formData,
+    headers: formData.getHeaders(),
+    params,
+  });
+
+  const skylink = response.data.skylink;
+  return `${uriSkynetPrefix}${skylink}`;
+};
+
 SkynetClient.prototype.uploadFile = async function (path, customOptions = {}) {
   const opts = { ...defaultUploadOptions, ...this.customOptions, ...customOptions };
 

--- a/src/upload.test.js
+++ b/src/upload.test.js
@@ -289,3 +289,33 @@ describe("uploadDirectory", () => {
     expect(data).toEqual(sialink);
   });
 });
+
+describe("uploadData", () => {
+  const filename = "testdata/file1.txt";
+  const data = "asdf";
+
+  beforeEach(() => {
+    axios.mockResolvedValue({ data: { skylink } });
+  });
+
+  it("should send post request to default portal", async () => {
+    const receivedSkylink = await client.uploadData(data, filename);
+
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: `${portalUrl}/skynet/skyfile`,
+        data: expect.objectContaining({
+          _streams: expect.arrayContaining([
+            expect.stringContaining(
+              'Content-Disposition: form-data; name="file"; filename="file1.txt"\r\nContent-Type: text/plain'
+            ),
+          ]),
+        }),
+        headers: expect.objectContaining({ "content-type": expect.stringContaining("multipart/form-data") }),
+        params: expect.anything(),
+      })
+    );
+
+    expect(receivedSkylink).toEqual(`sia://${skylink}`);
+  });
+});


### PR DESCRIPTION
# PULL REQUEST

## Overview

- Add `uploadData` and `downloadData`
- Add example/test scripts that use these methods.

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created
