### PR TITLE
Upgrade skynet-js and fix broken tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Types of changes:
 ### Added
 
 - Add `uploadData` and `downloadData`
+- Add SkyDB and SkyDB V2 (accessed with `client.db` and `client.dbV2`). By @parajbs in https://github.com/SkynetLabs/nodejs-skynet/pull/140
 
 ## [2.5.1]
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "form-data": "4.0.0",
     "mime": "^3.0.0",
     "skynet-js": "^4.2.3-beta",
-    "tus-js-client": "^2.3.0",
+    "@skynetlabs/tus-js-client": "^2.4.1",
     "url-join": "^4.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "axios": "0.27.2",
     "form-data": "4.0.0",
     "mime": "^3.0.0",
-    "skynet-js": "^4.0.26-beta",
+    "skynet-js": "^4.2.3-beta",
     "tus-js-client": "^2.3.0",
     "url-join": "^4.0.1"
   },

--- a/src/skydb.test.js
+++ b/src/skydb.test.js
@@ -1,8 +1,4 @@
-const axios = require("axios");
-
 const { SkynetClient, genKeyPairAndSeed, formatSkylink } = require("../index");
-
-jest.mock("axios");
 
 const dataKey = "testdatakey";
 const data = { example: "This is some example JSON data." };
@@ -20,10 +16,6 @@ const rawBytesData =
 
 jest.setTimeout(60000); // 60 second timeout
 jest.useRealTimers();
-
-beforeEach(() => {
-  axios.mockResolvedValue({ data: { skylink } });
-});
 
 describe("SkyDB V1", () => {
   describe("db.setDataLink", () => {

--- a/src/skydb_v2.test.js
+++ b/src/skydb_v2.test.js
@@ -1,8 +1,4 @@
-const axios = require("axios");
-
 const { SkynetClient, genKeyPairAndSeed, formatSkylink } = require("../index");
-
-jest.mock("axios");
 
 const dataKey = "testdatakey";
 const data = { example: "This is some example JSON data for SkyDB V2." };
@@ -20,10 +16,6 @@ const rawBytesData =
 
 jest.setTimeout(60000); // 60 second timeout
 jest.useRealTimers();
-
-beforeEach(() => {
-  axios.mockResolvedValue({ data: { skylink } });
-});
 
 describe("SkyDB V2", () => {
   describe("dbV2.getJSON", () => {

--- a/src/upload.js
+++ b/src/upload.js
@@ -4,7 +4,7 @@ const FormData = require("form-data");
 const fs = require("fs");
 const p = require("path");
 
-const { Upload } = require("tus-js-client");
+const { Upload } = require("@skynetlabs/tus-js-client");
 
 const { buildRequestHeaders, SkynetClient } = require("./client");
 const { defaultOptions, getFileMimeType, makeUrl, walkDirectory, uriSkynetPrefix } = require("./utils");

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,18 +776,18 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@skynetlabs/tus-js-client@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/@skynetlabs/tus-js-client/-/tus-js-client-2.3.0.tgz"
-  integrity sha512-piGvPlJh+Bu3Qf08bDlc/TnFLXE81KnFoPgvnsddNwTSLyyspxPFxJmHO5ki6SYyOl3HmUtGPoix+r2M2UpFEA==
+"@skynetlabs/tus-js-client@^2.4.0":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@skynetlabs/tus-js-client/-/tus-js-client-2.4.1.tgz#01e70e8c92fb3ec043b0c7da5206d7b96149c162"
+  integrity sha512-cc//2XeIqfZQ7rC182MbMwx/xTh1Cw1mQb2BmeHh6rO+coioyUSX71znPCsvijdKM+3NYXbhg5r/ZV5028OXfg==
   dependencies:
-    buffer-from "^0.1.1"
+    buffer-from "^1.1.2"
     combine-errors "^3.0.3"
     is-stream "^2.0.0"
     js-base64 "^2.6.1"
     lodash.throttle "^4.1.1"
     proper-lockfile "^2.0.1"
-    url-parse "^1.4.3"
+    url-parse "^1.5.7"
 
 "@types/babel__core@^7.1.14":
   version "7.1.15"
@@ -987,20 +987,13 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-axios@0.27.2:
+axios@0.27.2, axios@^0.27.2:
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
   integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
   dependencies:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
-
-axios@^0.26.0:
-  version "0.26.1"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz"
-  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
-  dependencies:
-    follow-redirects "^1.14.8"
 
 babel-jest@^28.1.0:
   version "28.1.0"
@@ -1121,11 +1114,6 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
-
-buffer-from@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz"
-  integrity sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==
 
 buffer-from@^1.0.0, buffer-from@^1.1.2:
   version "1.1.2"
@@ -1617,7 +1605,7 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz"
   integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
 
-follow-redirects@^1.14.8, follow-redirects@^1.14.9:
+follow-redirects@^1.14.9:
   version "1.14.9"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
@@ -2900,14 +2888,14 @@ sjcl@^1.0.8:
   resolved "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz"
   integrity sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==
 
-skynet-js@^4.0.26-beta:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/skynet-js/-/skynet-js-4.1.0.tgz#eccb84d04e9f42aa4f86ecb24fb4d59ed21e44cc"
-  integrity sha512-VmUjJ9QnLpfuQA2j7vzFh8JvukjQlX4QLGw1HY3VyslFPj92vPpyO8gqjPfzgbkR05TXL7CbdqZoLZr/RBDZPw==
+skynet-js@^4.2.0-beta:
+  version "4.2.0-beta"
+  resolved "https://registry.yarnpkg.com/skynet-js/-/skynet-js-4.2.0-beta.tgz#7ce7db2cb43b4c5b7e34ca511ceb13fc4ac59a71"
+  integrity sha512-9zciXyXm2WGlhyioxZDkN2CiGF5qEh0RzsQqZopS0l8ryNu/ZwN/4Sd4o2Ol34WwR0dyc/oj/FowOE4wPlVXJg==
   dependencies:
-    "@skynetlabs/tus-js-client" "^2.3.0"
+    "@skynetlabs/tus-js-client" "^2.4.0"
     async-mutex "^0.3.2"
-    axios "^0.26.0"
+    axios "^0.27.2"
     base32-decode "^1.0.0"
     base32-encode "^1.1.1"
     base64-js "^1.3.1"
@@ -3212,7 +3200,7 @@ url-join@^4.0.1:
   resolved "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz"
   integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
-url-parse@^1.4.3, url-parse@^1.5.1, url-parse@^1.5.7:
+url-parse@^1.5.1, url-parse@^1.5.7:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
   integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,7 +776,7 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@skynetlabs/tus-js-client@^2.4.0":
+"@skynetlabs/tus-js-client@^2.4.1":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@skynetlabs/tus-js-client/-/tus-js-client-2.4.1.tgz#01e70e8c92fb3ec043b0c7da5206d7b96149c162"
   integrity sha512-cc//2XeIqfZQ7rC182MbMwx/xTh1Cw1mQb2BmeHh6rO+coioyUSX71znPCsvijdKM+3NYXbhg5r/ZV5028OXfg==
@@ -2888,12 +2888,12 @@ sjcl@^1.0.8:
   resolved "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz"
   integrity sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==
 
-skynet-js@^4.2.0-beta:
-  version "4.2.0-beta"
-  resolved "https://registry.yarnpkg.com/skynet-js/-/skynet-js-4.2.0-beta.tgz#7ce7db2cb43b4c5b7e34ca511ceb13fc4ac59a71"
-  integrity sha512-9zciXyXm2WGlhyioxZDkN2CiGF5qEh0RzsQqZopS0l8ryNu/ZwN/4Sd4o2Ol34WwR0dyc/oj/FowOE4wPlVXJg==
+skynet-js@^4.2.3-beta:
+  version "4.2.3-beta"
+  resolved "https://registry.yarnpkg.com/skynet-js/-/skynet-js-4.2.3-beta.tgz#61310f061a5bcf47bd6ba1168739e88581ee7b00"
+  integrity sha512-5CHpA5FIgir+xuLCqCttb2gdbp69ctcYmV+4Th1rwSXoDNNyq3Q/SvdBaArceKUvQaMlbLVWhCZFRoxgPknY7A==
   dependencies:
-    "@skynetlabs/tus-js-client" "^2.4.0"
+    "@skynetlabs/tus-js-client" "^2.4.1"
     async-mutex "^0.3.2"
     axios "^0.27.2"
     base32-decode "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,19 +3148,6 @@ tslib@^2.1.0, tslib@^2.3.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
-tus-js-client@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/tus-js-client/-/tus-js-client-2.3.2.tgz#ec7007cf0d9a1eecf57977b7a015404c5e9cb2a6"
-  integrity sha512-5a2rm7gp+G7Z+ZB0AO4PzD/dwczB3n1fZeWO5W8AWLJ12RRk1rY4Aeb2VAYX9oKGE+/rGPrdxoFPA/vDSVKnpg==
-  dependencies:
-    buffer-from "^1.1.2"
-    combine-errors "^3.0.3"
-    is-stream "^2.0.0"
-    js-base64 "^2.6.1"
-    lodash.throttle "^4.1.1"
-    proper-lockfile "^2.0.1"
-    url-parse "^1.5.7"
-
 tweetnacl@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz"


### PR DESCRIPTION
# PULL REQUEST

## Overview

Upgrade `skynet-js`. Doing so broke the tests so I fixed that.

### More Details

The only relevant thing that changed in v4.2.0-beta is that we updated the axios
dependency, and it would seem like it behaves differently now. Previously, we
were partially mocking axios, but that didn't have any effect on the tests. Now,
however, it seems like the mock does not let through any actual network
requests, even if it is a partial mock. To fix this, all of the requests would
have to be mocked.

But I think it would be more valuable to let these tests keep making actual
network requests. I will remove the partial mock as it was actually a mistake
and not doing anything.

Credit: Thanks @parajbs!

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [x] Testing added or updated for new methods.
- [x] Verified if any changes impact the WebPortal Health Checks.
- [x] Appropriate documentation updated.
- [x] Changelog file created.

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->

Closes #150 
