### PR TITLE
Fix `Concurrent access prevented in SkyDB` error after test shutdown

### DIFF
--- a/integration/skydb_v2.test.js
+++ b/integration/skydb_v2.test.js
@@ -3,7 +3,6 @@ const { genKeyPairAndSeed, formatSkylink } = require("../index");
 
 const dataKey = "testdatakey";
 const data = { example: "This is some example JSON data for SkyDB V2." };
-const { publicKey, privateKey } = genKeyPairAndSeed();
 
 const skylink = "AAB1QJWQV0y2ynDXnJvOt0uh-THq-pJj2_layW5fjPXhTQ";
 const dataLink = "sia://AAChv5I6FTTqd8_6mtIOgwd5AhxurcYY9OSc-FacWlurEw";
@@ -15,50 +14,43 @@ const rawBytesData =
   "[123,34,95,100,97,116,97,34,58,123,34,101,120,97,109,112,108,101,34,58,34,84,104,105,115,32,105,115,32,115,111,109,101,32,101,120,97,109,112,108,101,32,74,83,79,78,32,100,97,116,97,32,50,46,34,125,44,34,95,118,34,58,50,125]";
 
 describe(`SkyDB V2 end to end integration tests for portal '${portal}'`, () => {
-  it("should get initial jsonData from skydb", async () => {
-    const receivedData = await client.dbV2.getJSON(publicKey, dataKey);
+  it("should set and get jsonData to skydb", async () => {
+    const { publicKey, privateKey } = genKeyPairAndSeed();
 
+    // Should get initial jsonData from skydb.
+    let receivedData = await client.dbV2.getJSON(publicKey, dataKey);
     await expect(receivedData.data).toEqual(null);
-  });
 
-  it("should set jsonData to skydb", async () => {
-    const receivedData = await client.dbV2.setJSON(privateKey, dataKey, data);
-
+    // Set jsonData.
+    receivedData = await client.dbV2.setJSON(privateKey, dataKey, data);
     await expect(formatSkylink(receivedData["dataLink"])).toEqual(`sia://${skylink}`);
-  });
 
-  it("should get new jsonData from skydb", async () => {
-    const receivedData = await client.dbV2.getJSON(publicKey, dataKey);
-
+    // Should get new jsonData from skydb.
+    receivedData = await client.dbV2.getJSON(publicKey, dataKey);
     await expect(receivedData.data).toEqual(data);
   });
 
-  it("should be a dataLink set", async () => {
+  it("should set and get entry data", async () => {
+    const { publicKey, privateKey } = genKeyPairAndSeed();
+
     await client.dbV2.setDataLink(privateKey, dataKey, dataLink);
-  });
 
-  it("should set entryData", async () => {
-    const receivedData = await client.dbV2.setEntryData(privateKey, dataKey, rawEntryData);
-
+    // Should set entryData.
+    let receivedData = await client.dbV2.setEntryData(privateKey, dataKey, rawEntryData);
     await expect(receivedData["data"]).toEqual(rawEntryData);
-  });
 
-  it("should get entryData", async () => {
-    const receivedData = await client.dbV2.getEntryData(publicKey, dataKey);
-
+    // Should get entryData.
+    receivedData = await client.dbV2.getEntryData(publicKey, dataKey);
     await expect(receivedData["data"]).toEqual(rawEntryData);
-  });
 
-  it("should get rawBytes", async () => {
-    const receivedData = await client.dbV2.getRawBytes(publicKey, dataKey);
-
+    // Should get rawBytes.
+    receivedData = await client.dbV2.getRawBytes(publicKey, dataKey);
     await expect(formatSkylink(receivedData["dataLink"])).toEqual(dataLink);
     await expect("[" + receivedData["data"] + "]").toEqual(rawBytesData);
-  });
 
-  it("should delete jsonData on skydb", async () => {
+    // Should delete jsonData on skydb.
     await client.dbV2.deleteJSON(privateKey, dataKey);
-    const receivedData = await client.dbV2.getJSON(publicKey, dataKey);
+    receivedData = await client.dbV2.getJSON(publicKey, dataKey);
 
     await expect(receivedData.data).toEqual(null);
     await expect(receivedData.dataLink).toEqual(null);


### PR DESCRIPTION

# PULL REQUEST

## Overview

It looks like when a test is unexpectedly quit, any open locks for SkyDB V2
entries stay open.

I figured we could avoid this by using random keys per test, instead of a single
pair of keys for all tests.

It's not clear yet whether this is a problem in production as the community has
not reported it. But this PR will make CI test output easier to read and debug.

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [x] Testing added or updated for new methods.
- [x] Verified if any changes impact the WebPortal Health Checks.
- [x] Appropriate documentation updated.
- [x] Changelog file created.

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
