### PR TITLE
Add format and disableDefaultPath options; fix downloadFileHns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Types of changes:
 
 ## Unreleased
 
+### Fixed
+
+- A bug has been fixed in `downloadFileHns` where it was creating a detached promise.
+
+### Added
+
+- `disableDefaultPath` option for `uploadDirectory`.
+- `format` option for `downloadFile` and `downloadFileHns`.
+
 ## [2.7.0]
 
 ### Added

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -25,6 +25,7 @@ const DEFAULT_BASE_OPTIONS = {
 
 const DEFAULT_DOWNLOAD_OPTIONS = {
   ...defaultOptions("/"),
+  format: "",
 };
 
 const DEFAULT_DOWNLOAD_HNS_OPTIONS = {
@@ -45,6 +46,7 @@ const DEFAULT_UPLOAD_OPTIONS = {
   portalDirectoryFileFieldname: "files[]",
   customFilename: "",
   customDirname: "",
+  disableDefaultPath: false,
   dryRun: false,
   errorPages: undefined,
   largeFileSize: TUS_CHUNK_SIZE,

--- a/src/upload.js
+++ b/src/upload.js
@@ -110,6 +110,14 @@ async function uploadLargeFile(client, stream, filename, filesize, opts) {
   });
 }
 
+/**
+ * Uploads a directory from the local filesystem to Skynet.
+ *
+ * @param {string} path - The path of the directory to upload.
+ * @param {Object} [customOptions] - Configuration options.
+ * @param {Object} [customOptions.disableDefaultPath=false] - If the value of `disableDefaultPath` is `true` no content is served if the skyfile is accessed at its root path.
+ * @returns - The skylink.
+ */
 SkynetClient.prototype.uploadDirectory = async function (path, customOptions = {}) {
   const opts = { ...DEFAULT_UPLOAD_OPTIONS, ...this.customOptions, ...customOptions };
 
@@ -149,6 +157,9 @@ SkynetClient.prototype.uploadDirectory = async function (path, customOptions = {
   }
   if (opts.errorPages) {
     params.errorpages = JSON.stringify(opts.errorPages);
+  }
+  if (opts.disableDefaultPath) {
+    params.disableDefaultPath = true;
   }
 
   if (opts.dryRun) params.dryrun = true;

--- a/src/upload.test.js
+++ b/src/upload.test.js
@@ -227,6 +227,7 @@ describe("uploadDirectory", () => {
       endpointPath: "/skynet/file",
       portalDirectoryFileFieldname: "filetest",
       customDirname: "/testpath",
+      disableDefaultPath: true,
       dryRun: true,
     });
 
@@ -242,6 +243,7 @@ describe("uploadDirectory", () => {
           headers: expect.anything(),
           params: {
             filename: "testpath",
+            disableDefaultPath: true,
             dryrun: true,
           },
         })


### PR DESCRIPTION
# PULL REQUEST

## Overview

See title.

I'm trying to release my script for deploying to `skynet-js.hns`. 
I needed to add these two options for it to work.

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [x] Testing added or updated for new methods.
- [x] Verified if any changes impact the WebPortal Health Checks.
- [x] Appropriate documentation updated.
- [x] Changelog file created.
