### PR TITLE
Version update to v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Types of changes:
 
 ## Unreleased
 
+## [2.8.0]
+
 ### Fixed
 
 - A bug has been fixed in `downloadFileHns` where it was creating a detached promise.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skynetlabs/skynet-nodejs",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Skynet SDK",
   "repository": "https://github.com/SkynetLabs/nodejs-skynet",
   "main": "index.js",


### PR DESCRIPTION
# PULL REQUEST

## Overview

```md
## [2.8.0]

### Fixed

- A bug has been fixed in `downloadFileHns` where it was creating a detached promise.

### Added

- `disableDefaultPath` option for `uploadDirectory`.
- `format` option for `downloadFile` and `downloadFileHns`.
```


